### PR TITLE
Correction of `gradle_command` string value

### DIFF
--- a/os_android_apk_builder/bp/_general_utils.py
+++ b/os_android_apk_builder/bp/_general_utils.py
@@ -14,4 +14,3 @@ def release_binary(release_command, project_path, gradle_path):
     gradle_command = f'{gradle_path} {release_command}'
     full_command = f'{cd_command} && {gradle_command}'
     os.system(full_command)
-    print(gradle_command)

--- a/os_android_apk_builder/bp/_general_utils.py
+++ b/os_android_apk_builder/bp/_general_utils.py
@@ -14,6 +14,7 @@ def release_binary(release_command, project_path, gradle_path):
         gradle_path = os.path.join(project_path, 'gradlew')
 
     cd_command = f'cd {project_path}'
-    gradle_command = f'{gradle_path} {release_command}'
+    #gradle_command = f'{gradle_path} {release_command}'
+    gradle_command = f'gradlew {release_command}'
     full_command = f'{cd_command} && {gradle_command}'
     os.system(full_command)

--- a/os_android_apk_builder/bp/_general_utils.py
+++ b/os_android_apk_builder/bp/_general_utils.py
@@ -1,20 +1,17 @@
 # system
 import os
 
-##########################################
-# just a boilerPlate for the apk release #
-##########################################
+
+#####################################################
+# just a boilerPlate for the apk/app bundle release #
+#####################################################
 
 
 # will run the command which will create the binary (apk/app bundle)
 def release_binary(release_command, project_path, gradle_path):
-
-    # if the gradle path is None, we will use the project's gradle wrapper
-    if gradle_path is None:
-        gradle_path = os.path.join(project_path, 'gradlew')
-
     cd_command = f'cd {project_path}'
-    #gradle_command = f'{gradle_path} {release_command}'
-    gradle_command = f'gradlew {release_command}'
+    gradle_path = '.\\gradlew' if gradle_path == './gradlew' and os.name == 'nt' else gradle_path
+    gradle_command = f'{gradle_path} {release_command}'
     full_command = f'{cd_command} && {gradle_command}'
     os.system(full_command)
+    print(gradle_command)


### PR DESCRIPTION
Since you are already running the `cd_command` to go inside the project directory, there should not be `project_path` before "gradlew".
I was having `System cannot find the file specified` issue when I was using it as it was. So, I changed the library code to generate the APK.
BEFORE:
```
cd /path/to/project
/path/to/project/gradlew assembleRelease
```

AFTER:
```
cd /path/to/project
gradlew assembleRelease
```
Corrected!